### PR TITLE
Fix errors, pin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Social media data creates an influx of data, where traditional methods for exami
 Paper: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3870554
 
 Github Repository: https://github.com/kj2013/twitter-deliberative-politics
+
+**Instructions**
+* This repository runs with Python 3.8 due to library dependencies on Python 3.8

--- a/app.py
+++ b/app.py
@@ -273,7 +273,6 @@ uncivil_model_SVC = pickle.load(open('ML Models/SVC/uncivil_model.pkl', 'rb'))
 
 ## Main Application
 st.set_page_config(layout="wide")
-st.set_option('deprecation.showPyplotGlobalUse', False)
 st.header("Dashboard: The quality of online political talk: evaluating machine learning approaches for measuring discourse quality")
 st.subheader("Abstract")
 st.markdown("""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-scikit-learn
+scikit-learn==1.0.2
 plotly==5.8.0
+Pillow==9.5.0
 streamlit
 wordcloud==1.8.1
 textblob==0.17.1


### PR DESCRIPTION
1. Pinned to `scikit-learn==1.0.2` since the pickled models are version dependent
2. Pinned to `Pillow==9.5.0` because of a dependency in wordcloud
3. Added a note in README that this app only runs with Python 3.8

Longer term, the app needs a more thorough refactor to retrain models with a more recent version of scikit, and upgrade the app to a more modern version of python (which will need some dependency upgrades). 